### PR TITLE
refactor: replace event edit and preview pages with slug-based routing

### DIFF
--- a/backend/api/models/event.model.js
+++ b/backend/api/models/event.model.js
@@ -140,6 +140,7 @@ const EventSchema = new mongoose.Schema({
     default: '',
   },
   reviewed: { type: Boolean, default: false },
+  slug: { type: String },
 })
 EventSchema.index({ eventLocation: '2dsphere' })
 

--- a/backend/api/routes/event.router.js
+++ b/backend/api/routes/event.router.js
@@ -14,6 +14,7 @@ const {
   deleteAllMyClosedEvents,
   updateStatusPromotion,
   getSitemapEvents,
+  getEventBySlug
 } = require('../controllers/event.controller')
 
 router
@@ -21,6 +22,7 @@ router
   .post('/', createEvent)
   .post('/promotion', createPromotion)
   .get('/', getAllEvents)
+  .get('/slug/:slug', getEventBySlug)
   .get('/sitemap.xml', getSitemapEvents) // ✅ SEO-compatible
   .get('/geolocation', searchNearbyEvents)
   .get('/user/:userId', getEventsByUserId)

--- a/backend/index.js
+++ b/backend/index.js
@@ -18,12 +18,14 @@ const {
   updateExpiredPromotions,
 } = require('./api/controllers/event.controller.js')
 
+const { updateSlugs } = require('./api/utils/index.js')
+
 const scrapeLaAgenda = require('./api/scraping/laAgenda.js')
 const scrapeAytoLasPalmas = require('./api/scraping/ayuntamientoLasPalmas.js')
 const scrapeAytoTenerife = require('./api/scraping/ayuntamientoTenerife.js')
 const scrapeGobCanarias = require('./api/scraping/gobiernoCanarias.js')
 const scrapeGobCanariasExpo = require('./api/scraping/gobiernoCanariasExpo.js')
-const scrapeCabildoGranCanaria = require('./api/scraping/culturaCabildoLasPalmas.js');
+const scrapeCabildoGranCanaria = require('./api/scraping/culturaCabildoLasPalmas.js')
 const scrapeTeaTenerife = require('./api/scraping/teaTenerife.js')
 const Scraper = require('./api/scraping/scraperWithPuppeteer.js')
 const scraper = new Scraper()
@@ -77,6 +79,7 @@ app.listen(process.env.PORT, async (error) => {
   console.info(`Evente API running on PORT ${process.env.PORT}`)
 })
 
+
 //check expired Subcriptions and promotions
 const runExpirationChecks = async () => {
   console.log('Running subscription + promotion expiration checks')
@@ -91,10 +94,10 @@ cron.schedule('0 1 * * *', () => {
   scrapeGobCanarias()
 })
 
- cron.schedule('30 1 * * *', () => {
+cron.schedule('30 1 * * *', () => {
   console.log('Checking La agenda')
   scrapeLaAgenda()
-}) 
+})
 
 cron.schedule('0 2 * * *', () => {
   console.log('Checking Ayuntamiento de Las Palmas Events')
@@ -121,15 +124,16 @@ cron.schedule('0 4 * * *', () => {
   removeDuplicateEvents()
 })
 
-
 cron.schedule('30 4 * * *', () => {
   console.log('Closing passed events')
   closePassedEvents()
 })
 
-cron.schedule('0 5 * * *', async () => {
+cron.schedule('00 5 * * *', updateSlugs)
+
+cron.schedule('30 5 * * *', async () => {
   console.log('Closing Browser')
-   scraper.closeBrowser()
+  scraper.closeBrowser()
 })
 
 module.exports = app

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -28,6 +28,7 @@
         "puppeteer": "^24.11.1",
         "puppeteer-extra": "^3.3.6",
         "puppeteer-extra-plugin-stealth": "^2.11.2",
+        "slugify": "^1.6.6",
         "stripe": "^16.6.0",
         "user-agents": "^1.1.589"
       },
@@ -4818,6 +4819,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/smart-buffer": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "puppeteer": "^24.11.1",
     "puppeteer-extra": "^3.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
+    "slugify": "^1.6.6",
     "stripe": "^16.6.0",
     "user-agents": "^1.1.589"
   },

--- a/backend/testScraper.js
+++ b/backend/testScraper.js
@@ -1,6 +1,9 @@
 require('dotenv').config()
 
 const dbConnect = require('./api/config/db')
+const slugify = require('slugify');
+const Event = require('./api/models/event.model.js')
+
 const scrapperGobiernoExpo = require('./api/scraping/gobiernoCanariasExpo')
 const scrapeAytoTenerife = require('./api/scraping/ayuntamientoTenerife.js')
 const scrapeAytoLasPalmas = require('./api/scraping/ayuntamientoLasPalmas.js')
@@ -13,6 +16,8 @@ const scraper = new Scraper()
 const {
   removeDuplicateEvents,
 } = require('./api/controllers/event.controller.js')
+
+
 async function main() {
   try {
     await dbConnect()
@@ -22,8 +27,9 @@ async function main() {
     //await scrapeAytoLasPalmas()
     //await scrapeAytoTenerife()
     //await scrapeTeaTenerife()
-    await scrapeLaAgenda()
-    await removeDuplicateEvents()
+    //await scrapeLaAgenda()
+    //await removeDuplicateEvents()
+    //await updateSlugs()
     console.log('Scraping completed successfully.')
   } catch (error) {
     console.error('Error during scraping:', error)
@@ -31,9 +37,10 @@ async function main() {
     await scraper.closeBrowser()
   }
 }
-main()
+ main()
   .then(() => process.exit(0))
   .catch((error) => {
     console.error('Error in main function:', error)
     process.exit(1)
   })
+ 

--- a/frontend/components/EventCard.vue
+++ b/frontend/components/EventCard.vue
@@ -70,7 +70,7 @@
         />
 
         <!-- Main content -->
-        <NuxtLink :to="`/events/${event._id}`" class="cursor-pointer">
+        <NuxtLink :to="`/events/${event.slug}`" class="cursor-pointer">
           <div class="px-4 py-2 flex justify-between">
             <!-- Categories -->
             <div class="flex flex-wrap gap-2">
@@ -148,7 +148,7 @@
             </div>
           </div>
         </NuxtLink>
-        <NuxtLink :to="`/events/${event._id}`" class="cursor-pointer">
+        <NuxtLink :to="`/events/${event.slug}`" class="cursor-pointer">
           <div class="flex flex-col justify-between items-start px-4">
             <h3 class="text-xl text-secondary font-semibold mb-2 line-clamp-2">
               {{ event.eventName }}
@@ -286,7 +286,7 @@ const isOwner = computed(() => {
 const share = () => {
   navigator.share({
     text: 'Vente a este evento!',
-    url: '/events/' + props.event._id,
+    url: '/events/' + props.event.slug,
   })
 }
 
@@ -309,7 +309,7 @@ const isGoldPayment = computed(() => getPaymentType.value === 'optima')
 const isPremiumPayment = computed(() => getPaymentType.value === 'optima plus')
 
 const editEvent = () => {
-  router.push(`/events/edit/${props.event._id}`)
+  router.push(`/events/edit/${props.event.slug}`)
 }
 
 const handleReviewed = async () => {

--- a/frontend/components/EventForm.vue
+++ b/frontend/components/EventForm.vue
@@ -93,17 +93,19 @@ const onSubmit = async () => {
   if (!eventStore.event.externalSource) {
     validateFields(t)
   }
-
+  
   if (eventStore.event.reviewed === false && props.isEditing && isAdmin) {
-    await eventStore.updateEventReviewed(eventStore.event._id, true)
+    const { data } = await eventStore.updateEventReviewed(eventStore.event._id, true);
+
   }
 
   if (Object.values(errors).every((error) => error === '')) {
+
     if (props.isEditing) {
       await eventStore.updateEvent()
 
       router.push(
-        `/events/preview/${eventStore.event._id}?type=${eventStore.eventType}`
+        `/events/preview/${eventStore.event.slug}?type=${eventStore.eventType}`
       )
     } else {
       eventStore.status = 'draft'
@@ -122,7 +124,7 @@ const onSubmit = async () => {
         }
         if (result) {
           router.push(
-            `/events/preview/${eventStore.event._id}?type=${eventStore.eventType}`
+            `/events/preview/${eventStore.event.slug}?type=${eventStore.eventType}`
           )
         } else {
           toast({

--- a/frontend/components/EventInfoForm.vue
+++ b/frontend/components/EventInfoForm.vue
@@ -330,7 +330,6 @@ const userStore = useUserStore()
 const hasEndDate = ref(false)
 const checkCodePromo = ref(false)
 const changeMap = ref(props.isEditing)
-
 const eventDiscounts = computed(() => {
   return [
     { label: t('onBoarding.step2Genres.all'), value: 'all' },
@@ -366,6 +365,7 @@ watch(
 )
 
 const eventStore = useEventStore()
+//TODO ARREGLAR ACTUALIZACION DEL EVENTTYPE
 
 const isClickTypeOfPay = ref(false)
 

--- a/frontend/components/FeaturedEvents.vue
+++ b/frontend/components/FeaturedEvents.vue
@@ -10,7 +10,7 @@
           <CarouselItem v-for="event in premiumEvents" :key="event.id">
             <Card class="border-0 flex items-center justify-center bg-gray-900">
               <CardContent class="bg-gray rounded-md">
-                <NuxtLink :to="`/events/${event._id}`">
+                <NuxtLink :to="`/events/${event.slug}`">
                   <img
                     :src="event.coverImage || 
                       event?.eventImages[0]?.url ||

--- a/frontend/components/PaymentOptions.vue
+++ b/frontend/components/PaymentOptions.vue
@@ -211,6 +211,7 @@ const choosePayment = async (plan) => {
   try {
     const userId = getUserId()
     const eventId = eventStore.event._id
+    const slug = eventStore.event.slug
     const eventDate = formatDate(eventStore.event.eventDate)
 
     if (plan.name === 'basic') {
@@ -223,7 +224,7 @@ const choosePayment = async (plan) => {
       if (result.success) {
         const publishResult = await eventStore.updateEventStatus(eventId, 'published')
         if (publishResult) {
-          router.push(`/events/${eventId}`)
+          router.push(`/events/${slug}`)
         } else {
           console.error('Failed to publish event')
         }

--- a/frontend/components/PromotionCard.vue
+++ b/frontend/components/PromotionCard.vue
@@ -45,7 +45,7 @@
         :src="defaultImage"
         class="ml-[1%] w-[98%] h-44 mt-[1%] object-contain rounded-t-lg z-0 bg-[#1a1a1a]"
       />
-      <NuxtLink :to="`/events/${promotion._id}`">
+      <NuxtLink :to="`/events/${promotion.slug}`">
         <!-- Main content -->
         <div class="px-3 py-2 flex justify-between p-4">
           <!-- Categories -->
@@ -127,7 +127,7 @@
           </div>
         </div>
       </NuxtLink>
-      <NuxtLink :to="`/events/${promotion._id}`">
+      <NuxtLink :to="`/events/${promotion.slug}`">
         <div class="flex flex-col justify-between items-start px-4">
           <h3 class="text-xl font-semibold mb-2">{{ promotion.eventName }}</h3>
           <p
@@ -266,7 +266,7 @@ const formattedDate = () => {
 }
 
 const editEvent = () => {
-  router.push(`/events/edit/${props.promotion._id}`)
+  router.push(`/events/edit/${props.promotion.slug}`)
 }
 
 const deleteEvent = async () => {
@@ -344,7 +344,7 @@ const handleSubscription = () => {
 const share = () => {
   navigator.share({
     text: 'Vente a este evento!',
-    url: '/events/' + props.promotion._id,
+    url: '/events/' + props.promotion.slug
   })
 }
 </script>

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -130,7 +130,7 @@ export default defineNuxtConfig({
     '/api/**': { cors: true },
     // Redirects legacy urls
     '/old-page': { redirect: '/new-page' },
-    '/event/:id': { ssr: true },
+    '/event/:slug': { ssr: true },
     '/api/clients/unsubscribe/**': {
       csurf: false,
     },

--- a/frontend/pages/dashboard/promotions.vue
+++ b/frontend/pages/dashboard/promotions.vue
@@ -43,11 +43,17 @@
       <FilterModal type="promotion" />
     </div>
     <hr class="mb-4 border-1 border-black w-full" />
-    <div v-if="limitedPromotions.filter((promotion) => promotion.status === 'closed').length > 0" class="w-full flex justify-end mb-4 md:mb-0">
+    <div
+      v-if="
+        limitedPromotions.filter((promotion) => promotion.status === 'closed')
+          .length > 0
+      "
+      class="w-full flex justify-end mb-4 md:mb-0"
+    >
       <Button
         class="bg-red-500 hover:bg-red-700 text-white"
         @click="tryToDelete = true"
-        >
+      >
         {{ $t('buttons.deleteAll') }}
       </Button>
     </div>
@@ -60,8 +66,12 @@
         :promotion="promotion"
       />
       <CustomModal v-model:open="tryToDelete">
-      <ConfirmModalClosedEvent @close="tryToDelete = false" type="promotion" @update:open="tryToDelete = $event" />
-    </CustomModal>
+        <ConfirmModalClosedEvent
+          @close="tryToDelete = false"
+          type="promotion"
+          @update:open="tryToDelete = $event"
+        />
+      </CustomModal>
       <p v-if="limitedPromotions.length === 0" class="text-gray-500 mt-4">
         {{ $t('notEventsFound') }}
       </p>
@@ -81,6 +91,7 @@
 
 <script setup>
 import { storeToRefs } from 'pinia'
+import { onMounted } from 'vue'
 const { t } = useI18n()
 const userStore = useUserStore()
 const eventStore = useEventStore()
@@ -88,7 +99,6 @@ const subscriptionStore = useSubscriptionStore()
 const { filteredEvents } = storeToRefs(eventStore)
 const userData = computed(() => userStore.userData)
 const tryToDelete = ref(false)
-
 
 const userRole = computed(() => userStore.userData?.role)
 
@@ -105,7 +115,7 @@ const optionsFilters = computed(() => {
 const selectedPromotion = ref('all')
 const eventDiscounts = computed(() => {
   return [
-  { label: t('onBoarding.step2Genres.all'), value: 'all' },
+    { label: t('onBoarding.step2Genres.all'), value: 'all' },
     { label: t('eventTypeDiscount.2x1'), value: '2x1' },
     { label: t('eventTypeDiscount.3x1'), value: '3x1' },
     { label: t('eventTypeDiscount.3x2'), value: '3x2' },
@@ -204,5 +214,9 @@ definePageMeta({
 
 useHead({
   title: 'Promotions',
+})
+
+onMounted(() => {
+  eventStore.fetchEvents()
 })
 </script>

--- a/frontend/pages/events/[slug].vue
+++ b/frontend/pages/events/[slug].vue
@@ -240,6 +240,9 @@ const isOpen = ref({
   status: false,
   type: null,
 })
+const slug = route.params.slug
+const { data, pending, error } = await eventStore.fetchEventBySlug(slug)
+const eventId = data?._id
 
 const eventType = computed(() => {
   return eventStore.event.eventType
@@ -247,11 +250,10 @@ const eventType = computed(() => {
 
 const { event } = storeToRefs(eventStore)
 const defaultImage = '/defaultImg.png'
-const eventId = route.params.id
 const isAdmin = userStore.userData?.role === 'admin'
 const isValidated = userStore?.userData?.isValidated
 const searchPaymentEvent = computed(() => {
-  let payment = eventStore.events.find((e) => e._id === eventId)
+  let payment = eventStore.events.find((e) => e._id === data?._id)
   return payment?.payment?.name
 })
 
@@ -271,7 +273,6 @@ const categoryServices = computed(() => {
   return eventStore.event?.categoriesOfServices
 })
 
-const { data, pending, error } = await eventStore.fetchEventById(eventId)
 
 if (error) {
   console.error('Error fetching event:', error)
@@ -282,7 +283,7 @@ const isOwner = computed(() => {
 })
 
 const editEvent = () => {
-  router.push(`/events/edit/${eventId}`)
+  router.push(`/events/edit/${slug}`)
 }
 
 const deleteEvent = async () => {
@@ -346,7 +347,7 @@ const publishEvent = async () => {
     if (isAdmin) {
       const result = await eventStore.updateEventByAdmin(eventId)
       if (result) {
-        router.push(`/events/${eventId}`)
+        router.push(`/events/${slug}`)
       } else {
         console.error('Failed to publish promotion')
         toast({
@@ -360,7 +361,7 @@ const publishEvent = async () => {
       if (isSubscriptionValid && !hasPublishedPromotions) {
         const result = await eventStore.updateEventStatus(eventId, 'published')
         if (result) {
-          router.push(`/events/${eventId}`)
+          router.push(`/events/${slug}`)
         } else {
           console.error('Failed to publish promotion')
         }
@@ -411,7 +412,7 @@ const copyToClipboard = async () => {
 const share = () => {
   navigator.share({
     text: "Vente a este evento!",
-    url: "/events/" + eventId
+    url: "/events/" + slug
   })
 }
 
@@ -437,7 +438,7 @@ useSeoMeta({
   ogTitle: event?.value?.eventName || 'Evento',
   ogDescription: event?.value?.eventDescription?.substring(0, 155) || '',
   ogImage: event?.value?.coverImage || defaultImage,
-  ogUrl: `https://evente.es/events/${eventId}`,
+  ogUrl: `https://evente.es/events/${slug}`,
 })
 
 </script>

--- a/frontend/pages/events/edit/[slug].vue
+++ b/frontend/pages/events/edit/[slug].vue
@@ -23,10 +23,10 @@ const eventStore = useEventStore()
 
 const { event, loading, error } = storeToRefs(eventStore)
 
-const eventId = route.params.id
+const slug = route.params.slug
 
 onMounted(() => {
-  eventStore.fetchEventById(eventId)
+  eventStore.fetchEventBySlug(slug)
 })
 
 useHead({

--- a/frontend/pages/events/preview/[slug].vue
+++ b/frontend/pages/events/preview/[slug].vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative px-6 md:px-12 mt-4 bg-background text-secondary">
     <div
-      @click="() => router.push(`/events/edit/${eventId}`)"
+      @click="() => router.push(`/events/edit/${slug}`)"
       class="flex items-center max-w-[160px] rounded-md gap-2 my-4 left-4 cursor-pointer border-2 border-primary bg-background p-2 hover:bg-primary"
     >
       <ArrowLeft />
@@ -56,7 +56,7 @@
           eventStore.eventPrice === 0 && eventStore.isFree !== 'not_available'
             ? $t('price.free')
             : eventStore.isFree === 'not_available'
-            ?  `${$t('eventPrice')}: ${$t('buttons.notAvailable')}`
+            ? `${$t('eventPrice')}: ${$t('buttons.notAvailable')}`
             : `${eventStore.eventPrice}€`
         }}</span>
       </div>
@@ -128,7 +128,7 @@
       >{{ $t('buttons.publish') }}</Button
     >
     <Button
-      @click="() => router.push(`/events/edit/${eventId}`)"
+      @click="() => router.push(`/events/edit/${slug}`)"
       class="mt-8 ml-4 bg-background text-secondary border-2 border-primary hover:bg-primary hover:text-black"
       >{{ $t('goEdit') }}</Button
     >
@@ -147,11 +147,12 @@ const router = useRouter()
 
 const hasDayDiff = computed(() => localStorage.dayDiff)
 
-const eventId = route.params.id
+const slug = route.params.slug
 const defaultImage = '/defaultImg.png'
-
+let eventId
 onMounted(async () => {
-  const result = await eventStore.fetchEventById(eventId)
+  const { data, pending, error } = await eventStore.fetchEventBySlug(slug)
+  eventId = data?._id
   eventStore.normalizeCategories()
 })
 
@@ -173,7 +174,7 @@ const publishEvent = async () => {
     if (isAdmin) {
       const result = await eventStore.updateEventByAdmin(eventId)
       if (result) {
-        return router.push(`/events/${eventId}`)
+        return router.push(`/events/${slug}`)
       } else {
         console.error('Failed to publish promotion')
         toast({
@@ -191,7 +192,7 @@ const publishEvent = async () => {
         const result = await eventStore.updateEventStatus(eventId, 'published')
         if (result) {
           await eventStore.fetchEvents()
-          router.push(`/events/${eventId}`)
+          router.push(`/events/${slug}`)
         } else {
           console.error('Failed to publish promotion')
         }
@@ -206,12 +207,12 @@ const publishEvent = async () => {
         )
       }
     } else if (eventStore.event.eventType === 'event') {
-      router.push(`/payment?id=${eventId}&type=${eventStore.event.eventType}`);
+      router.push(`/payment?id=${eventId}&type=${eventStore.event.eventType}`)
     }
   } catch (error) {
-    console.log('Error al publicar el evento:', error);
+    console.log('Error al publicar el evento:', error)
   }
-};
+}
 
 const checkIfUserHasPromotions = (event) => {
   if (event.eventType === 'event') return false

--- a/frontend/stores/eventStore.js
+++ b/frontend/stores/eventStore.js
@@ -291,6 +291,32 @@ export const useEventStore = defineStore('eventStore', {
       }
     },
 
+    async fetchEventBySlug(slug) {
+      this.loading = true
+      this.error = null
+
+      try {
+        const { data, error } = await useFetch(`/events/slug/${slug}`, {
+          baseURL: useRuntimeConfig().public.apiBaseUrl,
+        })
+
+        if (error.value) {
+          console.error('Error fetching event:', error.value)
+          this.error = error.value
+          return { error: error.value }
+        }
+
+        this.event = data.value?.result
+        return { data: this.event }
+      } catch (error) {
+        this.error = error.message
+        console.error('Error fetching event:', this.error)
+        return { error: this.error }
+      } finally {
+        this.loading = false
+      }
+    },
+
     async fetchUserEvents(userId) {
       const { data, error } = await useFetch(`/events/user/${userId}`, {
         baseURL: useRuntimeConfig().public.apiBaseUrl,
@@ -496,12 +522,14 @@ export const useEventStore = defineStore('eventStore', {
 
     // new
     async updateEventReviewed(eventId, reviewed) {
+      console.log('entrando en reviewed')
       try {
         const data = await $fetch(`/events/${eventId}`, {
           method: 'PATCH',
           body: { reviewed },
           baseURL: useRuntimeConfig().public.apiBaseUrl,
         })
+
 
         if (data.success) {
           this.event = data.result
@@ -571,9 +599,9 @@ export const useEventStore = defineStore('eventStore', {
         externalUrl: this.externalUrl,
         eventImages: this.eventImages,
         coverImage: this.coverImage,
-        categories: this.selectedCategories.map((cat) => typeof cat === 'object' ? 
-          (cat._id || cat.id) :
-          cat),
+        categories: this.selectedCategories.map((cat) =>
+          typeof cat === 'object' ? cat._id || cat.id : cat
+        ),
         categoriesOfServices: this.selectedCategoriesByServices,
         status: this.status,
         userId: this.userId,
@@ -716,11 +744,7 @@ export const useEventStore = defineStore('eventStore', {
                 event.eventEndDate?.month - 1,
                 event.eventEndDate?.day
               ),
-              new Date(
-                filterDate.year,
-                filterDate.month - 1,
-                filterDate.day
-              )
+              new Date(filterDate.year, filterDate.month - 1, filterDate.day)
             )
           ) {
             return false


### PR DESCRIPTION
- Removed the old event edit page and replaced it with a new slug-based edit page.
- Removed the old event preview page and replaced it with a new slug-based preview page.
- Updated the event store to include a method for fetching events by slug.
- Adjusted the event publishing logic to accommodate the new slug-based structure.
- Enhanced the UI components to reflect the changes in routing and data fetching.